### PR TITLE
Dynamic reference for libz

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -352,7 +352,7 @@ fi
 if build "zlib"; then
 	download "https://www.zlib.net/zlib-1.2.11.tar.gz" "zlib-1.2.11.tar.gz"
 	cd "$PACKAGES"/zlib-1.2.11 || exit
-	execute ./configure --prefix="${WORKSPACE}"
+	execute ./configure --static --prefix="${WORKSPACE}"
 	execute make -j $MJOBS
 	execute make install
 	build_done "zlib"


### PR DESCRIPTION
Current script compiles zlib dynamically and creates a hard reference to ~/ffmpeg-build-script/workspace/lib/libz.1.dylib, which makes it non-portable. This patch solves the problem and links zlib statically.